### PR TITLE
feat: Run `pnpm i` to auto update the lockifle

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -516,6 +516,8 @@ export async function runVersion({
     await exec("node", [resolveFrom(cwd, "@changesets/cli/bin.js"), cmd], {
       cwd,
     });
+
+    await exec("pnpm", ["install"], { cwd });
   }
 
   let searchQuery = `repo:${repo}+state:open+head:${versionBranch}+base:${branch}`;


### PR DESCRIPTION
Its becoming difficult to manually update the lockfile after every version update, so run `pnpm i` and commit when creating the release PR